### PR TITLE
BUG: WAL closed field shouldn't be used

### DIFF
--- a/cmd/kevo/server.go
+++ b/cmd/kevo/server.go
@@ -33,7 +33,7 @@ func NewServer(eng *engine.EngineFacade, config Config) *Server {
 	// Create a transaction registry directly from the transaction package
 	// The transaction registry can work with any type that implements BeginTransaction
 	txRegistry := transaction.NewRegistry()
-	
+
 	return &Server{
 		eng:        eng,
 		txRegistry: txRegistry,
@@ -86,7 +86,7 @@ func (s *Server) Start() error {
 
 	kaPolicy := keepalive.EnforcementPolicy{
 		MinTime:             10 * time.Second, // Minimum time a client should wait between pings
-		PermitWithoutStream: true,            // Allow pings even when there are no active streams
+		PermitWithoutStream: true,             // Allow pings even when there are no active streams
 	}
 
 	serverOpts = append(serverOpts,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -47,7 +47,7 @@ type ClientOptions struct {
 	// Performance options
 	Compression    CompressionType // Compression algorithm
 	MaxMessageSize int             // Maximum message size
-	
+
 	// Keepalive options
 	KeepaliveTime    time.Duration // Time between keepalive pings (0 for default)
 	KeepaliveTimeout time.Duration // Time to wait for ping ack (0 for default)
@@ -117,15 +117,15 @@ func NewClient(options ClientOptions) (*Client, error) {
 			PermitWithoutStream: true, // Allow pings even when there are no active streams
 		}
 	}
-	
+
 	transportOpts := transport.TransportOptions{
-		Timeout:        options.ConnectTimeout,
-		MaxMessageSize: options.MaxMessageSize,
-		Compression:    options.Compression,
-		TLSEnabled:     options.TLSEnabled,
-		CertFile:       options.CertFile,
-		KeyFile:        options.KeyFile,
-		CAFile:         options.CAFile,
+		Timeout:         options.ConnectTimeout,
+		MaxMessageSize:  options.MaxMessageSize,
+		Compression:     options.Compression,
+		TLSEnabled:      options.TLSEnabled,
+		CertFile:        options.CertFile,
+		KeyFile:         options.KeyFile,
+		CAFile:          options.CAFile,
 		KeepaliveParams: keepaliveParams,
 		RetryPolicy: transport.RetryPolicy{
 			MaxRetries:     options.MaxRetries,
@@ -243,15 +243,15 @@ func (c *Client) createTransportOptions(options ClientOptions) transport.Transpo
 			PermitWithoutStream: true, // Allow pings even when there are no active streams
 		}
 	}
-	
+
 	return transport.TransportOptions{
-		Timeout:        options.ConnectTimeout,
-		MaxMessageSize: options.MaxMessageSize,
-		Compression:    options.Compression,
-		TLSEnabled:     options.TLSEnabled,
-		CertFile:       options.CertFile,
-		KeyFile:        options.KeyFile,
-		CAFile:         options.CAFile,
+		Timeout:         options.ConnectTimeout,
+		MaxMessageSize:  options.MaxMessageSize,
+		Compression:     options.Compression,
+		TLSEnabled:      options.TLSEnabled,
+		CertFile:        options.CertFile,
+		KeyFile:         options.KeyFile,
+		CAFile:          options.CAFile,
 		KeepaliveParams: keepaliveParams,
 		RetryPolicy: transport.RetryPolicy{
 			MaxRetries:     options.MaxRetries,

--- a/pkg/common/iterator/filtered/filtered.go
+++ b/pkg/common/iterator/filtered/filtered.go
@@ -57,7 +57,7 @@ func (fi *FilteredIterator) IsTombstone() bool {
 // SeekToFirst positions at the first key that passes the filter
 func (fi *FilteredIterator) SeekToFirst() {
 	fi.iter.SeekToFirst()
-	
+
 	// Advance to the first key that passes the filter
 	if fi.iter.Valid() && !fi.keyFilter(fi.iter.Key()) {
 		fi.Next()
@@ -67,17 +67,17 @@ func (fi *FilteredIterator) SeekToFirst() {
 // SeekToLast positions at the last key that passes the filter
 func (fi *FilteredIterator) SeekToLast() {
 	// This is a simplistic implementation that may not be efficient
-	// For a production-quality implementation, we might want a more 
+	// For a production-quality implementation, we might want a more
 	// sophisticated approach
 	fi.iter.SeekToLast()
-	
+
 	// If we're at a valid position but it doesn't pass the filter,
 	// we need to find the last key that does
 	if fi.iter.Valid() && !fi.keyFilter(fi.iter.Key()) {
 		// Inefficient but correct - scan from beginning to find last valid key
 		var lastValidKey []byte
 		fi.iter.SeekToFirst()
-		
+
 		for fi.iter.Valid() {
 			if fi.keyFilter(fi.iter.Key()) {
 				lastValidKey = make([]byte, len(fi.iter.Key()))
@@ -85,7 +85,7 @@ func (fi *FilteredIterator) SeekToLast() {
 			}
 			fi.iter.Next()
 		}
-		
+
 		// If we found a valid key, seek to it
 		if lastValidKey != nil {
 			fi.iter.Seek(lastValidKey)
@@ -102,12 +102,12 @@ func (fi *FilteredIterator) Seek(target []byte) bool {
 	if !fi.iter.Seek(target) {
 		return false
 	}
-	
+
 	// If the current position doesn't pass the filter, find the next one that does
 	if !fi.keyFilter(fi.iter.Key()) {
 		return fi.Next()
 	}
-	
+
 	return true
 }
 

--- a/pkg/common/iterator/filtered/filtered_test.go
+++ b/pkg/common/iterator/filtered/filtered_test.go
@@ -111,60 +111,60 @@ func TestFilteredIterator(t *testing.T) {
 	}
 
 	baseIter := NewMockIterator(entries)
-	
+
 	// Filter for keys starting with 'a'
 	filter := func(key []byte) bool {
 		return bytes.HasPrefix(key, []byte("a"))
 	}
-	
+
 	filtered := NewFilteredIterator(baseIter, filter)
-	
+
 	// Test SeekToFirst and Next
 	filtered.SeekToFirst()
-	
+
 	if !filtered.Valid() {
 		t.Fatal("Expected valid position after SeekToFirst")
 	}
-	
+
 	if string(filtered.Key()) != "a1" {
 		t.Errorf("Expected key 'a1', got '%s'", string(filtered.Key()))
 	}
-	
+
 	if string(filtered.Value()) != "val1" {
 		t.Errorf("Expected value 'val1', got '%s'", string(filtered.Value()))
 	}
-	
+
 	if filtered.IsTombstone() {
 		t.Error("Expected non-tombstone for first entry")
 	}
-	
+
 	// Advance to next matching entry
 	if !filtered.Next() {
 		t.Fatal("Expected successful Next() call")
 	}
-	
+
 	if string(filtered.Key()) != "a3" {
 		t.Errorf("Expected key 'a3', got '%s'", string(filtered.Key()))
 	}
-	
+
 	if !filtered.IsTombstone() {
 		t.Error("Expected tombstone for second entry")
 	}
-	
+
 	// Advance again
 	if !filtered.Next() {
 		t.Fatal("Expected successful Next() call")
 	}
-	
+
 	if string(filtered.Key()) != "a5" {
 		t.Errorf("Expected key 'a5', got '%s'", string(filtered.Key()))
 	}
-	
+
 	// No more entries
 	if filtered.Next() {
 		t.Fatal("Expected end of iteration")
 	}
-	
+
 	if filtered.Valid() {
 		t.Fatal("Expected invalid position at end of iteration")
 	}
@@ -182,27 +182,27 @@ func TestPrefixIterator(t *testing.T) {
 
 	baseIter := NewMockIterator(entries)
 	prefixIter := NewPrefixIterator(baseIter, []byte("apple"))
-	
+
 	// Count matching entries
 	prefixIter.SeekToFirst()
-	
+
 	count := 0
 	for prefixIter.Valid() {
 		count++
 		prefixIter.Next()
 	}
-	
+
 	if count != 3 {
 		t.Errorf("Expected 3 entries with prefix 'apple', got %d", count)
 	}
-	
+
 	// Test Seek
 	prefixIter.Seek([]byte("apple3"))
-	
+
 	if !prefixIter.Valid() {
 		t.Fatal("Expected valid position after Seek")
 	}
-	
+
 	if string(prefixIter.Key()) != "apple3" {
 		t.Errorf("Expected key 'apple3', got '%s'", string(prefixIter.Key()))
 	}
@@ -220,27 +220,27 @@ func TestSuffixIterator(t *testing.T) {
 
 	baseIter := NewMockIterator(entries)
 	suffixIter := NewSuffixIterator(baseIter, []byte("_suffix"))
-	
+
 	// Count matching entries
 	suffixIter.SeekToFirst()
-	
+
 	count := 0
 	for suffixIter.Valid() {
 		count++
 		suffixIter.Next()
 	}
-	
+
 	if count != 3 {
 		t.Errorf("Expected 3 entries with suffix '_suffix', got %d", count)
 	}
-	
+
 	// Test seeking to find entries with suffix
 	suffixIter.Seek([]byte("key3"))
-	
+
 	if !suffixIter.Valid() {
 		t.Fatal("Expected valid position after Seek")
 	}
-	
+
 	if string(suffixIter.Key()) != "key3_suffix" {
 		t.Errorf("Expected key 'key3_suffix', got '%s'", string(suffixIter.Key()))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,12 +58,12 @@ type Config struct {
 	MaxLevelWithTombstones int     `json:"max_level_with_tombstones"` // Levels higher than this discard tombstones
 
 	// Transaction configuration
-	ReadOnlyTxTTL       int64 `json:"read_only_tx_ttl"`        // Time-to-live for read-only transactions in seconds (default: 180s)
-	ReadWriteTxTTL      int64 `json:"read_write_tx_ttl"`       // Time-to-live for read-write transactions in seconds (default: 60s)
-	IdleTxTimeout       int64 `json:"idle_tx_timeout"`         // Time after which an inactive transaction is considered idle in seconds (default: 30s)
-	TxCleanupInterval   int64 `json:"tx_cleanup_interval"`     // Interval for checking transaction TTLs in seconds (default: 30s)
-	TxWarningThreshold  int   `json:"tx_warning_threshold"`    // Percentage of TTL after which to log warnings (default: 75)
-	TxCriticalThreshold int   `json:"tx_critical_threshold"`   // Percentage of TTL after which to log critical warnings (default: 90)
+	ReadOnlyTxTTL       int64 `json:"read_only_tx_ttl"`      // Time-to-live for read-only transactions in seconds (default: 180s)
+	ReadWriteTxTTL      int64 `json:"read_write_tx_ttl"`     // Time-to-live for read-write transactions in seconds (default: 60s)
+	IdleTxTimeout       int64 `json:"idle_tx_timeout"`       // Time after which an inactive transaction is considered idle in seconds (default: 30s)
+	TxCleanupInterval   int64 `json:"tx_cleanup_interval"`   // Interval for checking transaction TTLs in seconds (default: 30s)
+	TxWarningThreshold  int   `json:"tx_warning_threshold"`  // Percentage of TTL after which to log warnings (default: 75)
+	TxCriticalThreshold int   `json:"tx_critical_threshold"` // Percentage of TTL after which to log critical warnings (default: 90)
 
 	mu sync.RWMutex
 }

--- a/pkg/engine/storage/retry.go
+++ b/pkg/engine/storage/retry.go
@@ -23,12 +23,11 @@ func DefaultRetryConfig() *RetryConfig {
 	}
 }
 
-// RetryOnWALRotating retries the operation if it fails with ErrWALRotating
-func (m *Manager) RetryOnWALRotating(operation func() error) error {
-	config := DefaultRetryConfig()
-	return m.RetryWithConfig(operation, config, isWALRotating)
-}
-
+// Commented out due to duplicate declaration with the one in manager.go
+// func (m *Manager) RetryOnWALRotating(operation func() error) error {
+// 	config := DefaultRetryConfig()
+// 	return m.RetryWithConfig(operation, config, isWALRotating)
+// }
 
 // RetryWithConfig retries an operation with the given configuration
 func (m *Manager) RetryWithConfig(operation func() error, config *RetryConfig, isRetryable func(error) bool) error {

--- a/pkg/engine/storage/sequence_test.go
+++ b/pkg/engine/storage/sequence_test.go
@@ -1,0 +1,143 @@
+// ABOUTME: Tests sequence number functionality in storage manager
+// ABOUTME: Verifies correct version selection during recovery with sequence numbers
+
+package storage
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KevoDB/kevo/pkg/config"
+	"github.com/KevoDB/kevo/pkg/stats"
+)
+
+// TestSequenceNumberVersioning tests that sequence numbers are properly tracked
+// and used for version selection during recovery.
+func TestSequenceNumberVersioning(t *testing.T) {
+	// Create temporary directories for the test
+	tempDir, err := os.MkdirTemp("", "sequence-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create subdirectories for SSTables and WAL
+	sstDir := filepath.Join(tempDir, "sst")
+	walDir := filepath.Join(tempDir, "wal")
+
+	// Create configuration
+	cfg := &config.Config{
+		Version:         config.CurrentManifestVersion,
+		SSTDir:          sstDir,
+		WALDir:          walDir,
+		MemTableSize:    1024 * 1024, // 1MB
+		MemTablePoolCap: 2,
+		MaxMemTables:    2,
+	}
+
+	// Create a stats collector
+	statsCollector := stats.NewAtomicCollector()
+
+	// Create a new storage manager
+	manager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create storage manager: %v", err)
+	}
+	defer manager.Close()
+
+	// Step 1: Add a key with initial value
+	testKey := []byte("test-key")
+	initialValue := []byte("initial-value")
+	err = manager.Put(testKey, initialValue)
+	if err != nil {
+		t.Fatalf("Failed to put initial value: %v", err)
+	}
+
+	// Verify the key is readable
+	value, err := manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value: %v", err)
+	}
+	if !bytes.Equal(initialValue, value) {
+		t.Errorf("Expected initial value %s, got %s", initialValue, value)
+	}
+
+	// Step 2: Flush to create an SSTable
+	err = manager.FlushMemTables()
+	if err != nil {
+		t.Fatalf("Failed to flush memtables: %v", err)
+	}
+
+	// Verify data is still accessible after flush
+	value, err = manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value after flush: %v", err)
+	}
+	if !bytes.Equal(initialValue, value) {
+		t.Errorf("Expected initial value %s after flush, got %s", initialValue, value)
+	}
+
+	// Step 3: Update the key with a new value
+	updatedValue := []byte("updated-value")
+	err = manager.Put(testKey, updatedValue)
+	if err != nil {
+		t.Fatalf("Failed to put updated value: %v", err)
+	}
+
+	// Verify the updated value is readable
+	value, err = manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get updated value: %v", err)
+	}
+	if !bytes.Equal(updatedValue, value) {
+		t.Errorf("Expected updated value %s, got %s", updatedValue, value)
+	}
+
+	// Step 4: Flush again to create another SSTable with the updated value
+	err = manager.FlushMemTables()
+	if err != nil {
+		t.Fatalf("Failed to flush memtables again: %v", err)
+	}
+
+	// Verify updated data is still accessible after second flush
+	value, err = manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value after second flush: %v", err)
+	}
+	if !bytes.Equal(updatedValue, value) {
+		t.Errorf("Expected updated value %s after second flush, got %s", updatedValue, value)
+	}
+
+	// Get the last sequence number
+	lastSeqNum := manager.lastSeqNum
+
+	// Step 5: Close the manager and simulate a recovery scenario
+	err = manager.Close()
+	if err != nil {
+		t.Fatalf("Failed to close manager: %v", err)
+	}
+
+	// Create a new manager to simulate recovery
+	recoveredManager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create recovered manager: %v", err)
+	}
+	defer recoveredManager.Close()
+
+	// Verify the key still has the latest value after recovery
+	recoveredValue, err := recoveredManager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value after recovery: %v", err)
+	}
+	if !bytes.Equal(updatedValue, recoveredValue) {
+		t.Errorf("Expected updated value %s after recovery, got %s", updatedValue, recoveredValue)
+	}
+
+	// Verify the sequence number was properly recovered
+	if recoveredManager.lastSeqNum < lastSeqNum {
+		t.Errorf("Recovered sequence number %d is less than last known sequence number %d",
+			recoveredManager.lastSeqNum, lastSeqNum)
+	}
+}

--- a/pkg/memtable/iterator_adapter.go
+++ b/pkg/memtable/iterator_adapter.go
@@ -88,3 +88,11 @@ func (a *IteratorAdapter) Valid() bool {
 func (a *IteratorAdapter) IsTombstone() bool {
 	return a.iter != nil && a.iter.IsTombstone()
 }
+
+// SequenceNumber returns the sequence number of the current entry
+func (a *IteratorAdapter) SequenceNumber() uint64 {
+	if !a.Valid() || a.iter.Entry() == nil {
+		return 0
+	}
+	return a.iter.Entry().seqNum
+}

--- a/pkg/memtable/skiplist.go
+++ b/pkg/memtable/skiplist.go
@@ -317,3 +317,11 @@ func (it *Iterator) Entry() *entry {
 	}
 	return it.current.entry
 }
+
+// SequenceNumber returns the sequence number of the current entry
+func (it *Iterator) SequenceNumber() uint64 {
+	if !it.Valid() {
+		return 0
+	}
+	return it.current.entry.seqNum
+}

--- a/pkg/replication/replica.go
+++ b/pkg/replication/replica.go
@@ -188,7 +188,7 @@ type Replica struct {
 
 	// Stream client for receiving WAL entries
 	streamClient replication_proto.WALReplicationService_StreamWALClient
-	
+
 	// Statistics for the replica
 	stats *ReplicaStats
 
@@ -869,12 +869,12 @@ func (r *Replica) connectToPrimary() error {
 func (r *Replica) processEntriesWithoutStateTransitions(response *replication_proto.WALStreamResponse) error {
 	entryCount := len(response.Entries)
 	fmt.Printf("Processing %d entries (no state transitions)\n", entryCount)
-	
+
 	// Track statistics
 	if r.stats != nil {
 		r.stats.TrackBatchReceived()
 		r.stats.TrackEntriesReceived(uint64(entryCount))
-		
+
 		// Calculate total bytes received
 		var totalBytes uint64
 		for _, entry := range response.Entries {
@@ -939,7 +939,7 @@ func (r *Replica) processEntriesWithoutStateTransitions(response *replication_pr
 	r.mu.Lock()
 	r.lastAppliedSeq = maxSeq
 	r.mu.Unlock()
-	
+
 	// Track applied entries in statistics
 	if r.stats != nil {
 		// Calculate the number of entries that were successfully applied
@@ -967,12 +967,12 @@ func (r *Replica) processEntriesWithoutStateTransitions(response *replication_pr
 func (r *Replica) processEntries(response *replication_proto.WALStreamResponse) error {
 	entryCount := len(response.Entries)
 	fmt.Printf("Processing %d entries\n", entryCount)
-	
+
 	// Track statistics
 	if r.stats != nil {
 		r.stats.TrackBatchReceived()
 		r.stats.TrackEntriesReceived(uint64(entryCount))
-		
+
 		// Calculate total bytes received
 		var totalBytes uint64
 		for _, entry := range response.Entries {
@@ -1037,7 +1037,7 @@ func (r *Replica) processEntries(response *replication_proto.WALStreamResponse) 
 	r.mu.Lock()
 	r.lastAppliedSeq = maxSeq
 	r.mu.Unlock()
-	
+
 	// Track applied entries in statistics
 	if r.stats != nil {
 		// Calculate the number of entries that were successfully applied

--- a/pkg/sstable/block/types.go
+++ b/pkg/sstable/block/types.go
@@ -2,8 +2,9 @@ package block
 
 // Entry represents a key-value pair within the block
 type Entry struct {
-	Key   []byte
-	Value []byte
+	Key         []byte
+	Value       []byte
+	SequenceNum uint64 // Sequence number for versioning
 }
 
 const (

--- a/pkg/sstable/iterator.go
+++ b/pkg/sstable/iterator.go
@@ -209,6 +209,19 @@ func (it *Iterator) IsTombstone() bool {
 	return it.dataBlockIter.Value() == nil
 }
 
+// SequenceNumber returns the sequence number of the current entry
+func (it *Iterator) SequenceNumber() uint64 {
+	it.mu.Lock()
+	defer it.mu.Unlock()
+
+	// Not valid means sequence number 0
+	if !it.initialized || it.dataBlockIter == nil || !it.dataBlockIter.Valid() {
+		return 0
+	}
+
+	return it.dataBlockIter.SequenceNumber()
+}
+
 // Error returns any error encountered during iteration
 func (it *Iterator) Error() error {
 	it.mu.Lock()

--- a/pkg/sstable/iterator_adapter.go
+++ b/pkg/sstable/iterator_adapter.go
@@ -57,3 +57,11 @@ func (a *IteratorAdapter) Valid() bool {
 func (a *IteratorAdapter) IsTombstone() bool {
 	return a.Valid() && a.iter.IsTombstone()
 }
+
+// SequenceNumber returns the sequence number of the current entry
+func (a *IteratorAdapter) SequenceNumber() uint64 {
+	if !a.Valid() {
+		return 0
+	}
+	return a.iter.SequenceNumber()
+}

--- a/pkg/sstable/writer.go
+++ b/pkg/sstable/writer.go
@@ -99,6 +99,11 @@ func (bm *BlockManager) Add(key, value []byte) error {
 	return bm.builder.Add(key, value)
 }
 
+// AddWithSequence adds a key-value pair with a sequence number to the current block
+func (bm *BlockManager) AddWithSequence(key, value []byte, seqNum uint64) error {
+	return bm.builder.AddWithSequence(key, value, seqNum)
+}
+
 // EstimatedSize returns the estimated size of the current block
 func (bm *BlockManager) EstimatedSize() uint32 {
 	return bm.builder.EstimatedSize()
@@ -285,6 +290,12 @@ func NewWriterWithOptions(path string, options WriterOptions) (*Writer, error) {
 // Add adds a key-value pair to the SSTable
 // Keys must be added in sorted order
 func (w *Writer) Add(key, value []byte) error {
+	return w.AddWithSequence(key, value, 0) // Default to sequence number 0 for backward compatibility
+}
+
+// AddWithSequence adds a key-value pair with a sequence number to the SSTable
+// Keys must be added in sorted order
+func (w *Writer) AddWithSequence(key, value []byte, seqNum uint64) error {
 	// Keep track of first and last keys
 	if w.entriesAdded == 0 {
 		w.firstKey = append([]byte(nil), key...)
@@ -296,8 +307,8 @@ func (w *Writer) Add(key, value []byte) error {
 		w.currentBloomFilter.AddKey(key)
 	}
 
-	// Add to block
-	if err := w.blockManager.Add(key, value); err != nil {
+	// Add to block with sequence number
+	if err := w.blockManager.AddWithSequence(key, value, seqNum); err != nil {
 		return fmt.Errorf("failed to add to block: %w", err)
 	}
 

--- a/pkg/transaction/manager.go
+++ b/pkg/transaction/manager.go
@@ -68,7 +68,7 @@ func (m *Manager) BeginTransaction(readOnly bool) (Transaction, error) {
 
 	// Create a new transaction
 	now := time.Now()
-	
+
 	// Set TTL based on transaction mode
 	var ttl time.Duration
 	if mode == ReadOnly {
@@ -76,16 +76,16 @@ func (m *Manager) BeginTransaction(readOnly bool) (Transaction, error) {
 	} else {
 		ttl = m.readWriteTxTTL
 	}
-	
+
 	tx := &TransactionImpl{
-		storage:       m.storage,
-		mode:          mode,
-		buffer:        NewBuffer(),
-		rwLock:        &m.txLock,
-		stats:         m,
-		creationTime:  now,
+		storage:        m.storage,
+		mode:           mode,
+		buffer:         NewBuffer(),
+		rwLock:         &m.txLock,
+		stats:          m,
+		creationTime:   now,
 		lastActiveTime: now,
-		ttl:           ttl,
+		ttl:            ttl,
 	}
 
 	// Set transaction as active

--- a/pkg/transaction/transaction.go
+++ b/pkg/transaction/transaction.go
@@ -62,7 +62,7 @@ func (tx *TransactionImpl) Get(key []byte) ([]byte, error) {
 	if !tx.active.Load() {
 		return nil, ErrTransactionClosed
 	}
-	
+
 	// Update last active time
 	tx.lastActiveTime = time.Now()
 
@@ -89,7 +89,7 @@ func (tx *TransactionImpl) Put(key, value []byte) error {
 	if !tx.active.Load() {
 		return ErrTransactionClosed
 	}
-	
+
 	// Update last active time
 	tx.lastActiveTime = time.Now()
 
@@ -113,7 +113,7 @@ func (tx *TransactionImpl) Delete(key []byte) error {
 	if !tx.active.Load() {
 		return ErrTransactionClosed
 	}
-	
+
 	// Update last active time
 	tx.lastActiveTime = time.Now()
 
@@ -138,7 +138,7 @@ func (tx *TransactionImpl) NewIterator() iterator.Iterator {
 		// Return an empty iterator
 		return &emptyIterator{}
 	}
-	
+
 	// Update last active time
 	tx.lastActiveTime = time.Now()
 
@@ -172,7 +172,7 @@ func (tx *TransactionImpl) NewRangeIterator(startKey, endKey []byte) iterator.It
 		// Return an empty iterator
 		return &emptyIterator{}
 	}
-	
+
 	// Update last active time
 	tx.lastActiveTime = time.Now()
 

--- a/pkg/transport/interface.go
+++ b/pkg/transport/interface.go
@@ -3,7 +3,7 @@ package transport
 import (
 	"context"
 	"time"
-	
+
 	"google.golang.org/grpc/keepalive"
 )
 
@@ -28,14 +28,14 @@ type RetryPolicy struct {
 
 // TransportOptions contains common configuration across all transport types
 type TransportOptions struct {
-	Timeout        time.Duration
-	RetryPolicy    RetryPolicy
-	Compression    CompressionType
-	MaxMessageSize int
-	TLSEnabled     bool
-	CertFile       string
-	KeyFile        string
-	CAFile         string
+	Timeout         time.Duration
+	RetryPolicy     RetryPolicy
+	Compression     CompressionType
+	MaxMessageSize  int
+	TLSEnabled      bool
+	CertFile        string
+	KeyFile         string
+	CAFile          string
 	KeepaliveParams *keepalive.ClientParameters // Optional keepalive parameters for gRPC clients
 }
 

--- a/pkg/wal/batch.go
+++ b/pkg/wal/batch.go
@@ -134,7 +134,8 @@ func (b *Batch) Write(w *WAL) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if atomic.LoadInt32(&w.closed) == 1 {
+	status := atomic.LoadInt32(&w.status)
+	if status == WALStatusClosed {
 		return ErrWALClosed
 	}
 

--- a/pkg/wal/wal.go
+++ b/pkg/wal/wal.go
@@ -93,7 +93,6 @@ type WAL struct {
 	lastSync      time.Time
 	batchByteSize int64
 	status        int32 // Using atomic int32 for status flags
-	closed        int32 // Atomic flag indicating if WAL is closed
 	mu            sync.Mutex
 
 	// Observer-related fields


### PR DESCRIPTION
In ae75f293 the `status` field was added to support the `WALStatusRotating` status, moving from a binary open/closed to a trinary open/rotating/closed status.

However, me being a little dummy, apparently, didn't remove the old `closed` field, and worse, I forgot to change a spot in the batch Write handling, which may have led to some issues when writing batches to a closed WAL. To be fair, you shouldn't be doing that, but also, we should be checking the right stuff so we can tell you this is a dumb idea.