### PR TITLE
fix: wal write failure race condition during rotation possibility

### DIFF
--- a/pkg/engine/storage/manager.go
+++ b/pkg/engine/storage/manager.go
@@ -63,10 +63,9 @@ type Manager struct {
 	stats stats.Collector
 
 	// Concurrency control
-	mu         sync.RWMutex // Main lock for engine state
-	flushMu    sync.Mutex   // Lock for flushing operations
-	rotatingMu sync.RWMutex // Separate mutex for rotation state
-	rotating   atomic.Bool  // Flag indicating rotation in progress
+	mu       sync.RWMutex // Main lock for engine state
+	flushMu  sync.Mutex   // Lock for flushing operations
+	rotating atomic.Bool  // Flag indicating rotation in progress
 }
 
 // NewManager creates a new storage manager

--- a/pkg/engine/storage/sequence_test.go
+++ b/pkg/engine/storage/sequence_test.go
@@ -1,6 +1,3 @@
-// ABOUTME: Tests sequence number functionality in storage manager
-// ABOUTME: Verifies correct version selection during recovery with sequence numbers
-
 package storage
 
 import (

--- a/pkg/engine/storage/tombstone_flush_test.go
+++ b/pkg/engine/storage/tombstone_flush_test.go
@@ -1,0 +1,254 @@
+// ABOUTME: Tests tombstone preservation during memtable flush to SSTable
+// ABOUTME: Verifies deleted keys remain deleted after restart through SSTable persistence
+
+package storage
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KevoDB/kevo/pkg/config"
+	"github.com/KevoDB/kevo/pkg/sstable"
+	"github.com/KevoDB/kevo/pkg/stats"
+)
+
+// TestTombstonePreservationInFlush tests that tombstones (deletion markers)
+// are properly written to SSTables during memtable flush and that deleted
+// keys remain deleted after recovery.
+func TestTombstonePreservationInFlush(t *testing.T) {
+	// Create temporary directories for the test
+	tempDir, err := os.MkdirTemp("", "tombstone-flush-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create subdirectories for SSTables and WAL
+	sstDir := filepath.Join(tempDir, "sst")
+	walDir := filepath.Join(tempDir, "wal")
+
+	// Create configuration
+	cfg := &config.Config{
+		Version:         config.CurrentManifestVersion,
+		SSTDir:          sstDir,
+		WALDir:          walDir,
+		MemTableSize:    1024, // Small size to force flush
+		MemTablePoolCap: 2,
+		MaxMemTables:    2,
+	}
+
+	// Create a stats collector
+	statsCollector := stats.NewAtomicCollector()
+
+	// Create a new storage manager
+	manager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create storage manager: %v", err)
+	}
+	defer manager.Close()
+
+	// Step 1: Add a key with initial value
+	testKey := []byte("test-key")
+	initialValue := []byte("initial-value")
+	err = manager.Put(testKey, initialValue)
+	if err != nil {
+		t.Fatalf("Failed to put initial value: %v", err)
+	}
+
+	// Verify the key is readable
+	value, err := manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value: %v", err)
+	}
+	if string(value) != string(initialValue) {
+		t.Errorf("Expected initial value %s, got %s", initialValue, value)
+	}
+
+	// Step 2: Delete the key (creates tombstone in memtable)
+	err = manager.Delete(testKey)
+	if err != nil {
+		t.Fatalf("Failed to delete key: %v", err)
+	}
+
+	// Verify the key is no longer accessible
+	_, err = manager.Get(testKey)
+	if err != ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound after deletion, got: %v", err)
+	}
+
+	// Step 3: Force flush to write tombstone to SSTable
+	err = manager.FlushMemTables()
+	if err != nil {
+		t.Fatalf("Failed to flush memtables: %v", err)
+	}
+
+	// Verify the key is still not accessible after flush
+	_, err = manager.Get(testKey)
+	if err != ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound after flush, got: %v", err)
+	}
+
+	// Step 4: Verify tombstone was actually written to SSTable
+	sstables := manager.GetSSTables()
+	if len(sstables) == 0 {
+		t.Fatal("Expected at least one SSTable to be created after flush")
+	}
+
+	// Check that the SSTable contains the tombstone
+	foundTombstone := false
+	for _, sstablePath := range sstables {
+		reader, err := sstable.OpenReader(sstablePath)
+		if err != nil {
+			t.Fatalf("Failed to open SSTable %s: %v", sstablePath, err)
+		}
+
+		iter := reader.NewIterator()
+		for iter.SeekToFirst(); iter.Valid(); iter.Next() {
+			if string(iter.Key()) == string(testKey) {
+				value := iter.Value()
+				tombstone := iter.IsTombstone()
+				t.Logf("Found key %s in SSTable %s: value=%v (len=%d), tombstone=%v",
+					testKey, sstablePath, value, len(value), tombstone)
+
+				if tombstone {
+					foundTombstone = true
+					t.Logf("Found tombstone for key %s in SSTable %s", testKey, sstablePath)
+				} else {
+					t.Errorf("Found key %s in SSTable but it's not a tombstone (value: %v)", testKey, value)
+				}
+				break
+			}
+		}
+		reader.Close()
+	}
+
+	if !foundTombstone {
+		t.Error("Tombstone was not found in any SSTable - deletion not persisted!")
+	}
+
+	// Step 5: Close and reopen to simulate restart
+	err = manager.Close()
+	if err != nil {
+		t.Fatalf("Failed to close manager: %v", err)
+	}
+
+	// Create a new manager to simulate recovery
+	recoveredManager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create recovered manager: %v", err)
+	}
+	defer recoveredManager.Close()
+
+	// Step 6: Verify the key is still deleted after recovery
+	_, err = recoveredManager.Get(testKey)
+	if err != ErrKeyNotFound {
+		t.Errorf("Expected ErrKeyNotFound after recovery, got: %v", err)
+	}
+
+	t.Log("Tombstone preservation test passed - deletions survive restart!")
+}
+
+// TestTombstoneWithSubsequentPut tests that a tombstone followed by a new put
+// works correctly after flush and recovery.
+func TestTombstoneWithSubsequentPut(t *testing.T) {
+	// Create temporary directories for the test
+	tempDir, err := os.MkdirTemp("", "tombstone-put-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create subdirectories for SSTables and WAL
+	sstDir := filepath.Join(tempDir, "sst")
+	walDir := filepath.Join(tempDir, "wal")
+
+	// Create configuration
+	cfg := &config.Config{
+		Version:         config.CurrentManifestVersion,
+		SSTDir:          sstDir,
+		WALDir:          walDir,
+		MemTableSize:    1024, // Small size to force flush
+		MemTablePoolCap: 2,
+		MaxMemTables:    2,
+	}
+
+	// Create a stats collector
+	statsCollector := stats.NewAtomicCollector()
+
+	// Create a new storage manager
+	manager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create storage manager: %v", err)
+	}
+	defer manager.Close()
+
+	testKey := []byte("test-key")
+
+	// Step 1: Put initial value
+	initialValue := []byte("initial-value")
+	err = manager.Put(testKey, initialValue)
+	if err != nil {
+		t.Fatalf("Failed to put initial value: %v", err)
+	}
+
+	// Step 2: Delete the key
+	err = manager.Delete(testKey)
+	if err != nil {
+		t.Fatalf("Failed to delete key: %v", err)
+	}
+
+	// Step 3: Put a new value for the same key
+	newValue := []byte("new-value")
+	err = manager.Put(testKey, newValue)
+	if err != nil {
+		t.Fatalf("Failed to put new value: %v", err)
+	}
+
+	// Verify the new value is accessible
+	value, err := manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get new value: %v", err)
+	}
+	if string(value) != string(newValue) {
+		t.Errorf("Expected new value %s, got %s", newValue, value)
+	}
+
+	// Step 4: Force flush
+	err = manager.FlushMemTables()
+	if err != nil {
+		t.Fatalf("Failed to flush memtables: %v", err)
+	}
+
+	// Verify the new value is still accessible after flush
+	value, err = manager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value after flush: %v", err)
+	}
+	if string(value) != string(newValue) {
+		t.Errorf("Expected new value %s after flush, got %s", newValue, value)
+	}
+
+	// Step 5: Recovery test
+	err = manager.Close()
+	if err != nil {
+		t.Fatalf("Failed to close manager: %v", err)
+	}
+
+	recoveredManager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create recovered manager: %v", err)
+	}
+	defer recoveredManager.Close()
+
+	// Verify the new value is still accessible after recovery
+	recoveredValue, err := recoveredManager.Get(testKey)
+	if err != nil {
+		t.Fatalf("Failed to get value after recovery: %v", err)
+	}
+	if string(recoveredValue) != string(newValue) {
+		t.Errorf("Expected new value %s after recovery, got %s", newValue, recoveredValue)
+	}
+
+	t.Log("Tombstone with subsequent put test passed!")
+}

--- a/pkg/engine/storage/tombstone_flush_test.go
+++ b/pkg/engine/storage/tombstone_flush_test.go
@@ -1,6 +1,3 @@
-// ABOUTME: Tests tombstone preservation during memtable flush to SSTable
-// ABOUTME: Verifies deleted keys remain deleted after restart through SSTable persistence
-
 package storage
 
 import (

--- a/pkg/engine/storage/wal_rotation_stress_test.go
+++ b/pkg/engine/storage/wal_rotation_stress_test.go
@@ -1,0 +1,204 @@
+// ABOUTME: Stress test for WAL rotation race condition under concurrent load
+// ABOUTME: Validates enhanced atomic WAL swap implementation handles concurrent writes properly
+package storage
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/KevoDB/kevo/pkg/config"
+	"github.com/KevoDB/kevo/pkg/stats"
+	"github.com/KevoDB/kevo/pkg/wal"
+)
+
+// TestWALRotationStress tests WAL rotation under heavy concurrent load
+func TestWALRotationStress(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := &config.Config{
+		Version:         config.CurrentManifestVersion,
+		SSTDir:          tempDir + "/sst",
+		WALDir:          tempDir + "/wal",
+		MemTableSize:    1024 * 1024, // 1MB
+		MaxMemTables:    3,
+		MemTablePoolCap: 5,
+	}
+
+	statsCollector := stats.NewAtomicCollector()
+	manager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+
+	const (
+		numWriters      = 10
+		numRotations    = 5
+		writesPerWriter = 100
+	)
+
+	var (
+		totalWrites      int64
+		successfulWrites int64
+		rotationErrors   int64
+		writeErrors      int64
+		wg               sync.WaitGroup
+	)
+
+	// Start concurrent writers
+	for i := 0; i < numWriters; i++ {
+		wg.Add(1)
+		go func(writerID int) {
+			defer wg.Done()
+
+			for j := 0; j < writesPerWriter; j++ {
+				key := fmt.Sprintf("writer%d-key%d", writerID, j)
+				value := fmt.Sprintf("value-%d-%d", writerID, j)
+
+				atomic.AddInt64(&totalWrites, 1)
+
+				err := manager.Put([]byte(key), []byte(value))
+				if err != nil {
+					if err == wal.ErrWALRotating {
+						atomic.AddInt64(&rotationErrors, 1)
+					} else {
+						atomic.AddInt64(&writeErrors, 1)
+						t.Logf("Write error: %v", err)
+					}
+				} else {
+					atomic.AddInt64(&successfulWrites, 1)
+				}
+
+				// Small delay to allow rotation opportunities
+				time.Sleep(100 * time.Microsecond)
+			}
+		}(i)
+	}
+
+	// Start concurrent WAL rotations
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < numRotations; i++ {
+			// Wait a bit between rotations
+			time.Sleep(50 * time.Millisecond)
+
+			err := manager.RotateWAL()
+			if err != nil {
+				t.Logf("Rotation error: %v", err)
+			}
+
+			// Check if rotation state is properly managed
+			if manager.isRotating() {
+				t.Logf("Rotation %d in progress", i+1)
+				// Allow some time for rotation to complete
+				time.Sleep(10 * time.Millisecond)
+			}
+		}
+	}()
+
+	// Wait for all operations to complete
+	wg.Wait()
+
+	// Verify results
+	t.Logf("Test completed:")
+	t.Logf("  Total writes attempted: %d", atomic.LoadInt64(&totalWrites))
+	t.Logf("  Successful writes: %d", atomic.LoadInt64(&successfulWrites))
+	t.Logf("  Rotation errors (retried): %d", atomic.LoadInt64(&rotationErrors))
+	t.Logf("  Other write errors: %d", atomic.LoadInt64(&writeErrors))
+
+	// Verify that most writes succeeded (allowing for some rotation conflicts)
+	if atomic.LoadInt64(&successfulWrites) < atomic.LoadInt64(&totalWrites)*8/10 {
+		t.Errorf("Too many writes failed: %d successful out of %d total",
+			atomic.LoadInt64(&successfulWrites), atomic.LoadInt64(&totalWrites))
+	}
+
+	// Verify no unexpected write errors occurred
+	if atomic.LoadInt64(&writeErrors) > 0 {
+		t.Errorf("Unexpected write errors occurred: %d", atomic.LoadInt64(&writeErrors))
+	}
+
+	// Verify data integrity by reading back some values
+	for i := 0; i < 5; i++ {
+		key := fmt.Sprintf("writer%d-key%d", 0, i)
+		expectedValue := fmt.Sprintf("value-%d-%d", 0, i)
+
+		value, err := manager.Get([]byte(key))
+		if err != nil {
+			t.Logf("Error reading key %s: %v", key, err)
+			continue
+		}
+
+		if value != nil && string(value) == expectedValue {
+			t.Logf("Successfully verified key %s", key)
+		}
+	}
+}
+
+// TestWALRotationAtomicity tests the atomicity of WAL rotation operations
+func TestWALRotationAtomicity(t *testing.T) {
+	tempDir := t.TempDir()
+
+	cfg := &config.Config{
+		Version:         config.CurrentManifestVersion,
+		SSTDir:          tempDir + "/sst",
+		WALDir:          tempDir + "/wal",
+		MemTableSize:    1024 * 1024,
+		MaxMemTables:    3,
+		MemTablePoolCap: 5,
+	}
+
+	statsCollector := stats.NewAtomicCollector()
+	manager, err := NewManager(cfg, statsCollector)
+	if err != nil {
+		t.Fatalf("Failed to create manager: %v", err)
+	}
+	defer manager.Close()
+
+	// Test that WAL pointer is never nil during rotation
+	const numIterations = 100
+
+	var wg sync.WaitGroup
+
+	// Continuously check WAL availability
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < numIterations*10; i++ {
+			currentWAL := manager.getWAL()
+			if currentWAL == nil {
+				t.Errorf("WAL pointer was nil during operation %d", i)
+			}
+			time.Sleep(100 * time.Microsecond)
+		}
+	}()
+
+	// Perform rapid rotations
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		for i := 0; i < numIterations; i++ {
+			err := manager.RotateWAL()
+			if err != nil {
+				t.Logf("Rotation %d failed: %v", i, err)
+			}
+			time.Sleep(1 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// Final verification
+	currentWAL := manager.getWAL()
+	if currentWAL == nil {
+		t.Error("WAL pointer is nil after all rotations completed")
+	}
+
+	t.Logf("Atomicity test completed successfully")
+}

--- a/pkg/engine/storage/wal_rotation_stress_test.go
+++ b/pkg/engine/storage/wal_rotation_stress_test.go
@@ -1,5 +1,3 @@
-// ABOUTME: Stress test for WAL rotation race condition under concurrent load
-// ABOUTME: Validates enhanced atomic WAL swap implementation handles concurrent writes properly
 package storage
 
 import (


### PR DESCRIPTION
I've never seen this issue specifically, but it does exist before this fix. But...

During rotation, the new wal gets created and assigned, then the old wal status transitions through WALStatusRotating to WALStatusClosed, and if there are concurrent operations, they can see an inconsistent state during the atomic swap.

This fixes it.